### PR TITLE
Improve usability of `sconecas_sessionmanager` svidstore plugin

### DIFF
--- a/doc/plugin_agent_svidstore_sconecas_sessionmanager.md
+++ b/doc/plugin_agent_svidstore_sconecas_sessionmanager.md
@@ -17,10 +17,11 @@ When the SVIDs are updated, the plugin takes care of creating (or updating) sess
 
 | Configuration                           | Description |
 | ----------------------------------------| ----------- |
-| cas_address                             |  CAS HTTPS connection string |
+| cas_connection_string                   |  CAS HTTPS connection string |
 | cas_client_certificate                  |  Client certificate used to authorize the plugin |
 | cas_client_key                          |  Client certificate key |
 | trust_anchor_certificate                |  CAS identity certiticate: the plugin uses this certificate to ensure connections only with a known, attested CAS |
+| insecure_skip_verify_tls                |  Skip TLS verification in connection with the configured CAS (**do not use in production**) |
 | cas_predecessor_dir                     |  Data path where the plugin will keep predecessors of each session |
 |            *                            |  **The next configurables define templates to be used along with placeholders to mint the desired sessions (the placeholders are presented in the next section)** |
 | svid_session_template_file              |  Template file for sessions that carry the SVIDs and private keys |
@@ -32,7 +33,7 @@ A sample configuration:
 ```
   SVIDStore "sconecas_sessionmanager" {
     plugin_data {
-      cas_address = "https://cas.scone:8081"
+      cas_connection_string = "https://cas.scone:8081"
       cas_client_certificate = "/run/spire/config/cas-client.crt"
       cas_client_key = "/run/spire/config/cas-client.key"
       trust_anchor_certificate = "/run/spire/config/trust-anchor.crt"

--- a/doc/plugin_agent_svidstore_sconecas_sessionmanager.md
+++ b/doc/plugin_agent_svidstore_sconecas_sessionmanager.md
@@ -53,8 +53,10 @@ The selectors of the type `sconecas_sessionmanager` are used to describe the ses
 
 | Selector                        | Example                                   | Description                                    |
 | ------------------------------- | ----------------------------------------- | ---------------------------------------------- |
-| `sconecas_sessionmanager:session_name` | `sconecas_sessionmanager:confidential-apps/mariadb-1` | Name of the session posted into SCONE CAS |
+| `sconecas_sessionmanager:session_name` | `sconecas_sessionmanager:confidential-apps/mariadb-1` | Name of the session posted into SCONE CAS that will import the SVIDs |
 | `sconecas_sessionmanager:session_hash`        | `sconecas_sessionmanager:session_hash:03aa3f5e2779b625a455651b54866447f995a2970d164581b4073044435359ed`         | HASH of the session returned by the SCONE CLI or CAS API  |
+| `sconecas_sessionmanager:trust_bundle_session_name`   | `sconecas_sessionmanager:trust_bundle_session_name:spire-ca` | Name that replaces the `<\trust-bundle-session-name>` placeholder in the `bundle_session_template_file` |
+| `sconecas_sessionmanager:fed_bundles_session_name` | `sconecas_sessionmanager:trust_bundle_session_name:fed-bundles` | Name that replaces the `<\fed-bundles-session-name>` placeholder in the `federated_bundles_session_template_file` |
 
 sconecas_sessionmanager:session_hash
 
@@ -71,13 +73,17 @@ The placeholders needed by the plugin for each session are:
 |         `svid_session_template_file`      |              *             |                                 *                                 |
 |                     *                     |          `<\svid>`         |         SVID leaf certificate and its intermediates (PEM)         |
 |                     *                     |        `<\svid-key>`       |                           SVID key (PEM)                          |
-|                     *                     | `<\session-name-selector>` | Name of the session that will import the SVID and the private key |
-|                     *                     | `<\session-hash-selector>` | HASH of the session that will import the SVID and the private key |
+|                     *                     | `<\session-name-selector>` | Value of the `session_name` selector (Name of the session that will import the SVID and the private key) |
+|                     *                     | `<\session-hash-selector>` | Value of the `session_hash` selector (HASH of the session that will import the SVID and the private key) |
 |                     *                     |      `<\predecessor>`      |                       Sessions' predecessors                      |
 |       `bundle_session_template_file`      |              *             |                                 *                                 |
+|                     *                     |      `<\trust-bundle-session-name>`     |      Value of the `trust_bundle_session_name` selector                    |
 |                     *                     |      `<\trust-bundle>`     |                     Trust bundle for the SVIDs                    |
+|                     *                     |      `<\predecessor>`      |                       Sessions' predecessors                      |
 | `federated_bundles_session_template_file` |              *             |                                 *                                 |
+|                     *                     |      `<\fed-bundles-session-name>`     |      Value of the `fed_bundles_session_name` selector                    |
 |                                           |   `<\federated-bundles>`   |            Federated bundles associated with the SVIDs            |
+|                     *                     |      `<\predecessor>`      |                       Sessions' predecessors                      |
 
 **SVID session template examples** 
 
@@ -103,7 +109,7 @@ secrets:
 **Bundle session template**
 
 ```yaml
-name: spire-ca
+name: spire-ca-<\trust-bundle-session-name>
 version: "0.3"
 predecessor: <\predecessor>
 secrets:
@@ -117,7 +123,7 @@ secrets:
 **Federated bundles session template**
 
 ```yaml
-name: spire-federated-bundles
+name: spire-fed-bundles-<\fed-bundles-session-name>
 version: "0.3"
 predecessor: <\predecessor>
 secrets:

--- a/doc/plugin_agent_svidstore_sconecas_sessionmanager.md
+++ b/doc/plugin_agent_svidstore_sconecas_sessionmanager.md
@@ -57,7 +57,7 @@ The selectors of the type `sconecas_sessionmanager` are used to describe the ses
 | `sconecas_sessionmanager:session_name` | `sconecas_sessionmanager:session_name:confidential-apps/mariadb-1` | Name of the session posted into SCONE CAS that will import the SVIDs |
 | `sconecas_sessionmanager:session_hash`        | `sconecas_sessionmanager:session_hash:03aa3f5e2779b625a455651b54866447f995a2970d164581b4073044435359ed`         | HASH of the session returned by the SCONE CLI or CAS API  |
 | `sconecas_sessionmanager:trust_bundle_session_name`   | `sconecas_sessionmanager:trust_bundle_session_name:spire-ca` | Name that replaces the `<\trust-bundle-session-name>` placeholder in the `bundle_session_template_file` |
-| `sconecas_sessionmanager:fed_bundles_session_name` | `sconecas_sessionmanager:trust_bundle_session_name:fed-bundles` | Name that replaces the `<\fed-bundles-session-name>` placeholder in the `federated_bundles_session_template_file` |
+| `sconecas_sessionmanager:fed_bundles_session_name` | `sconecas_sessionmanager:fed_bundles_session_name:fed-bundles` | Name that replaces the `<\fed-bundles-session-name>` placeholder in the `federated_bundles_session_template_file` |
 
 sconecas_sessionmanager:session_hash
 
@@ -72,7 +72,8 @@ The placeholders needed by the plugin for each session are:
 |             Template file type            |         Placeholder        |                           Replaced with                           |
 |:-----------------------------------------:|:--------------------------:|:-----------------------------------------------------------------:|
 |         `svid_session_template_file`      |              *             |                                 *                                 |
-|                     *                     |          `<\svid>`         |         SVID leaf certificate and its intermediates (PEM)         |
+|                     *                     |          `<\svid>`         |         SVID leaf certificate (PEM)         |
+|                     *                     |          `<\svid-intermediates>`         |         SVID intermediate certificates (PEM)         |
 |                     *                     |        `<\svid-key>`       |                           SVID key (PEM)                          |
 |                     *                     | `<\session-name-selector>` | Value of the `session_name` selector (Name of the session that will import the SVID and the private key) |
 |                     *                     | `<\session-hash-selector>` | Value of the `session_hash` selector (HASH of the session that will import the SVID and the private key) |
@@ -97,16 +98,25 @@ secrets:
     kind: x509
     value: |
         <\svid>
+    issuer: svid-intermediates
     export:
         session: <\session-name-selector>
         session_hash: <\session-hash-selector>
     private_key: svid_key
+  - name: svid-intermediates
+    kind: x509-ca
+    value: |
+        <\svid-intermediates>
+    export:
+        session: <\session-name-selector>
+        session_hash: <\session-hash-selector>
   - name: svid_key
     kind: private-key
     value: |
-       <\svid-key>
+        <\svid-key>
     export:
         session: <\session-name-selector>
+        session_hash: <\session-hash-selector>
 ```
 
 **Bundle session template**

--- a/doc/plugin_agent_svidstore_sconecas_sessionmanager.md
+++ b/doc/plugin_agent_svidstore_sconecas_sessionmanager.md
@@ -1,6 +1,6 @@
 # Agent plugin: SVIDStore "sconecas_sessionmanager"
 
-The `sconecas_sessionmanager` plugin stores in [SCONE CAS](https://sconedocs.github.io/CASOverview/) the resulting X509-SVIDs of the entries that the agent is entitled to. It is necessary to have an entry with the `-svidStore` flag set.
+The `sconecas_sessionmanager` plugin stores in [SCONE CAS](https://sconedocs.github.io/CASOverview/) the resulting X509-SVIDs of the entries that the agent is entitled to. It is necessary to have an entry with the `-storeSVID` flag set.
 
 The plugin uses session templates to give users more flexibility. Each template has placeholders used by the plugin to inject information and constraints for access control in the secret store.
 
@@ -37,6 +37,7 @@ A sample configuration:
       cas_client_certificate = "/run/spire/config/cas-client.crt"
       cas_client_key = "/run/spire/config/cas-client.key"
       trust_anchor_certificate = "/run/spire/config/trust-anchor.crt"
+      insecure_skip_verify_tls = false
 
       cas_predecessor_dir = "/run/spire"
       svid_session_template_file = "/run/spire/config/svid.template"
@@ -53,7 +54,7 @@ The selectors of the type `sconecas_sessionmanager` are used to describe the ses
 
 | Selector                        | Example                                   | Description                                    |
 | ------------------------------- | ----------------------------------------- | ---------------------------------------------- |
-| `sconecas_sessionmanager:session_name` | `sconecas_sessionmanager:confidential-apps/mariadb-1` | Name of the session posted into SCONE CAS that will import the SVIDs |
+| `sconecas_sessionmanager:session_name` | `sconecas_sessionmanager:session_name:confidential-apps/mariadb-1` | Name of the session posted into SCONE CAS that will import the SVIDs |
 | `sconecas_sessionmanager:session_hash`        | `sconecas_sessionmanager:session_hash:03aa3f5e2779b625a455651b54866447f995a2970d164581b4073044435359ed`         | HASH of the session returned by the SCONE CLI or CAS API  |
 | `sconecas_sessionmanager:trust_bundle_session_name`   | `sconecas_sessionmanager:trust_bundle_session_name:spire-ca` | Name that replaces the `<\trust-bundle-session-name>` placeholder in the `bundle_session_template_file` |
 | `sconecas_sessionmanager:fed_bundles_session_name` | `sconecas_sessionmanager:trust_bundle_session_name:fed-bundles` | Name that replaces the `<\fed-bundles-session-name>` placeholder in the `federated_bundles_session_template_file` |
@@ -102,6 +103,8 @@ secrets:
     private_key: svid_key
   - name: svid_key
     kind: private-key
+    value: |
+       <\svid-key>
     export:
         session: <\session-name-selector>
 ```

--- a/pkg/agent/plugin/svidstore/sconecas/scone.go
+++ b/pkg/agent/plugin/svidstore/sconecas/scone.go
@@ -30,6 +30,7 @@ const (
 	noPredHashMsg                          = "Session already exists, please specify predecessor hash"
 	predecessorPlaceholder                 = "<\\predecessor>"
 	svidPlaceholder                        = "<\\svid>"
+	svidIntermediatesPlaceholder           = "<\\svid-intermediates>"
 	svidKeyPlaceholder                     = "<\\svid-key>"
 	sessionNameSelectorPlaceholder         = "<\\session-name-selector>"
 	sessionHashSelectorPlaceholder         = "<\\session-hash-selector>"
@@ -38,6 +39,7 @@ const (
 	federatedBundlesPlaceholder            = "<\\federated-bundles>"
 	federatedBundlesSessionNamePlaceholder = "<\\fed-bundles-session-name>"
 	nameYAMLKey                            = "name:"
+	endCertificateStr                      = "-----END CERTIFICATE-----\n"
 )
 
 // BuiltIn returns the a new plugin instance
@@ -368,8 +370,13 @@ func (p *SessionManagerPlugin) generateFederatedBundlesSessionText(federatedBund
 }
 
 func (p *SessionManagerPlugin) generateSVIDSessionText(svidChain string, privKey string, workloadInfo *sconeWorkloadInfo, sessionName string) string {
+	svidChainSplitted := strings.SplitN(svidChain, endCertificateStr, 2)
+	svid := svidChainSplitted[0] + endCertificateStr
+	intermediates := svidChainSplitted[1]
+
 	session := strings.ReplaceAll(p.templateInfo.svidSessionTemplate, predecessorPlaceholder, p.readPredecessor(sessionName))
-	session = strings.ReplaceAll(session, svidPlaceholder, pemToSconeInjectionFile(svidChain))
+	session = strings.ReplaceAll(session, svidPlaceholder, pemToSconeInjectionFile(svid))
+	session = strings.ReplaceAll(session, svidIntermediatesPlaceholder, pemToSconeInjectionFile(intermediates))
 	session = strings.ReplaceAll(session, svidKeyPlaceholder, pemToSconeInjectionFile(privKey))
 	session = strings.ReplaceAll(session, sessionNameSelectorPlaceholder, workloadInfo.CasSessionName)
 	session = strings.ReplaceAll(session, sessionHashSelectorPlaceholder, workloadInfo.CasSessionHash)


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [x] Documentation updated?

**Description of change**
Added a new configurable to skip TLS verify in connections with CASes. Also, changed the `cas_addr` configurable to `cas_connection_string`.

Now, the names for sessions with the bundle and sessions with federated bundles are configurable via new placeholders and new selectors.

